### PR TITLE
Add a giphy alias for compat with slack command

### DIFF
--- a/src/giphy-gifme.coffee
+++ b/src/giphy-gifme.coffee
@@ -28,6 +28,6 @@ getRandomGiphyGif = (msg, tags) ->
     msg.send(response.data.image_url)
 
 module.exports = (robot) ->
-  robot.respond /gif me(.*)/i, (msg) ->
+  robot.respond /gif me|giphy(.*)/i, (msg) ->
     tags = msg.match[1].trim().split(', ')
     getRandomGiphyGif(msg, tags)


### PR DESCRIPTION
I'm trying to migrate folks from  the slack integration for giphy, and it would be helpful if that command worked here too :)